### PR TITLE
Fix: AUTO_DETECT_TIME_SYSTEM was using "time_system.use_custom".

### DIFF
--- a/common/src/main/java/de/mrjulsen/mcdragonlib/config/ModServerConfig.java
+++ b/common/src/main/java/de/mrjulsen/mcdragonlib/config/ModServerConfig.java
@@ -17,7 +17,7 @@ public class ModServerConfig {
         USE_CUSTOM = BUILDER.comment(new String[] { "When ON, the custom time settings from the common config are used. When OFF, the standard vanilla time system is used. (Default: OFF)" })
             .define("time_system.use_custom", false);
         AUTO_DETECT_TIME_SYSTEM = BUILDER.comment(new String[] { "When ON, DragonLib tries to detect time changing mods (like TimeControl) and uses its settings. When OFF, Vanilla or Custom is used. (Default: ON)" })
-            .define("time_system.use_custom", false);
+            .define("time_system.auto_detect_time_system", true);
         PREFERRED_MOD = BUILDER.comment(new String[] { "Specifies the preferred time changing mod. If multiple such mods are installed, it cannot be clearly determined which mod DragonLib is using to retrieve the data. This option allows you to specify a particular mod. However, installing multiple such mods simultaneously is not recommended. If this value is empty, the mod will be selected automatically, as before. If the specified mod does not exist, vanilla will be used. (Default: '')" })
             .define("time_system.preferred_mod", "");
 


### PR DESCRIPTION
Hi, I've noticed this when trying to use the time API.

AUTO_DETECT_TIME_SYSTEM uses the config key "time_system.use_custom", the same from USE_CUSTOM. Probably a copy-paste mistake.

As a result, the config was not generated correctly and there was no way to change AUTO_DETECT_TIME_SYSTEM .